### PR TITLE
ci((publish)): update trigger for push to main branch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,7 +1,8 @@
 name: Cuki-Publish
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
Based on https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359/3, pushes to
`main` occur when merging.