### PR TITLE
fix((docs)): update documentation about token permissions

### DIFF
--- a/INITIALIZATION.md
+++ b/INITIALIZATION.md
@@ -1,0 +1,15 @@
+### This project requires two tokens
+- npm token
+- github token
+
+Each of these tokesn will be provided to the Project's setting's `Security and variables/actions` page.
+
+#### Github Token
+Based on [this article](https://www.tevpro.com/blog/calibrating-permissions-using-fine-grained-tokens), we need
+specific permissions when using the Granular-access tokens from Github. Specifically:
+- Actions - Access: Read/Write
+- Commit Statuses - Access: Read-only
+- Contents - Access: Read/Write
+- Issues - Access: Read/Write
+- Metadata - Access: Read-only
+- Pull Requests - Access: Read-only


### PR DESCRIPTION
This is not really a "fix", but I want to trigger a patch, to allow Semantic Release library to run through it's CI action again.